### PR TITLE
[FEATURE] add configurable ignore_patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ parameters:
     - "typo3conf/ext/extension/Resources/Private/Templates/List.xml"
 ````
 
-there you can override some conevtions:
+there you can override some convention:
 
 
 | Key                                 | Default                       |

--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ if pluswerk/grumphp-config should not edit your composer.json than you must add 
   }
 }
 ````
+
+### You want to override settings?:
+
+
+Make a new grumphp.yml config file. You can put it in the root folder.
+````yaml
+imports:
+  - { resource: vendor/pluswerk/grumphp-config/grumphp.yml }
+
+
+parameters:
+  convention.xmllint_ignore_pattern:
+    - "typo3conf/ext/extension/Resources/Private/Templates/List.xml"
+````
+
+there you can override some conevtions:
+
+
+| Key                                 | Default                       |
+|-------------------------------------|-------------------------------|
+| convention.xmllint_ignore_pattern   | []                            |
+| convention.yamllint_ignore_pattern  | []                            |
+| convention.xlifflint_ignore_pattern | "#typo3conf/l10n/(.*)#"       |

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,6 +4,9 @@ parameters:
   stop_on_failure: false
   hide_circumvention_tip: true
   ignore_unstaged_changes: false #brocken
+  convention.xmllint_ignore_pattern: []
+  convention.yamllint_ignore_pattern: []
+  convention.xlifflint_ignore_pattern: ["#typo3conf/l10n/(.*)#"]
   ascii:
     failed: ./vendor/pluswerk/grumphp-config/logo.txt
     succeeded: ./vendor/pluswerk/grumphp-config/logo.txt
@@ -40,11 +43,12 @@ parameters:
       standard: "PSR2"
       show_warnings: false
       tab_width: 4
-    xmllint: ~
-    yamllint: ~
+    xmllint:
+      ignore_patterns: "%convention.xmllint_ignore_pattern%"
+    yamllint:
+      ignore_patterns: "%convention.yamllint_ignore_pattern%"
     xlifflint:
-      ignore_patterns:
-        - "#typo3conf/l10n/(.*)#"
+      ignore_patterns: "%convention.xlifflint_ignore_pattern%"
     plus_bom_fixer:
       metadata:
         priority: 1


### PR DESCRIPTION
### You want to override settings?:


Make a new grumphp.yml config file. You can put it in the root folder.
````yaml
imports:
  - { resource: vendor/pluswerk/grumphp-config/grumphp.yml }


parameters:
  convention.xmllint_ignore_pattern:
    - "typo3conf/ext/extension/Resources/Private/Templates/List.xml"
````

there you can override some convetions:


| Key                                 | Default                       |
|-------------------------------------|-------------------------------|
| convention.xmllint_ignore_pattern   | []                            |
| convention.yamllint_ignore_pattern  | []                            |
| convention.xlifflint_ignore_pattern | "#typo3conf/l10n/(.*)#"       |