### PR TITLE
[BUGFIX] Fix abandoned package dependency (#39)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "pluswerk/grumphp-xliff-task": "3.*",
         "squizlabs/php_codesniffer": ">=3.5.0 <4.0.0",
         "sensiolabs/security-checker": "6.*",
-        "jakub-onderka/php-parallel-lint": "1.*"
+        "php-parallel-lint/php-parallel-lint": "1.*"
     },
     "extra": {
         "class": "PLUS\\Composer\\Plugin"


### PR DESCRIPTION
The package jakub-onderka/php-parallel-lint is abandoned
and should be replaced by php-parallel-lint/php-parallel-lint.