### PR TITLE
Invert ddev env detection

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -76,4 +76,4 @@ grumphp:
     EXEC_GRUMPHP_COMMAND: "$DDEV_EXEC php"
     ENV:
       # DDEV_EXEC will be empty if no ddev is found or you are in the ddev container.
-      DDEV_EXEC: '$([ -z "$IS_DDEV_PROJECT" ] && echo "$(which ddev)")'
+      DDEV_EXEC: '$([ -n "$IS_DDEV_PROJECT" ] && echo "$(which ddev)")'


### PR DESCRIPTION
Fix erroneous detection of `$IS_DDEV_PROJECT`: 

Given that you have ddev installed but the project is **not** a ddev project (so no `$IS_DDEV_PROJECT`):

The `-z` would check for an empty `$IS_DDEV_PROJECT` -> true
The `which` would return the ddev binary -> true

true + true = use ddev on this project, where it actually isn't a ddev project.

What you actually want to check for is that `$IS_DDEV_PROJECT` is **not** empty -> `-n`

That omits that it could be actually set to "false", or "0", or any other falsy value, but I guess that's okay.