### PR TITLE
[BUGFIX] remove deprecated Rector classes used in skip() method

### DIFF
--- a/src/RectorSettings.php
+++ b/src/RectorSettings.php
@@ -11,9 +11,6 @@ use Rector\CodeQuality\Rector\If_\ArrayExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
-use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
-use Rector\CodingStyle\Rector\If_\NullableCompareToNullRector;
 use Rector\Php70\Rector\Assign\ListSwapArrayOrderRector;
 use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
 use Rector\PostRector\Rector\NameImportingPostRector;
@@ -164,11 +161,6 @@ final class RectorSettings
     {
         return [
             /**
-             * FROM: if($object) {
-             * TO:   if($object !== null) {
-             */
-            NullableCompareToNullRector::class,
-            /**
              * FROM: if ($dateTime === null) {
              * TO:   if (! $dateTime instanceof DateTime) {
              */
@@ -178,11 +170,6 @@ final class RectorSettings
              * TO:   if ($someClass instanceof SomeClass && $someClass->someMethod()) {
              */
             BinaryOpNullableToInstanceofRector::class,
-            /**
-             * FROM: if(count($array)) {
-             * TO:   if($array !== []) {
-             */
-            CountArrayToEmptyArrayComparisonRector::class,
             /**
              * FROM: protected string $name;
              * TO:   private string  $name;

--- a/src/RectorSettings.php
+++ b/src/RectorSettings.php
@@ -11,6 +11,7 @@ use Rector\CodeQuality\Rector\If_\ArrayExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
 use Rector\Php70\Rector\Assign\ListSwapArrayOrderRector;
 use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
 use Rector\PostRector\Rector\NameImportingPostRector;


### PR DESCRIPTION
<img width="1216" height="138" alt="image" src="https://github.com/user-attachments/assets/88f84a0b-e7d7-4398-86df-7780638782db" />

a warning is thrown in every rector run